### PR TITLE
Add coming soon overlay sitewide while site is under construction

### DIFF
--- a/_includes/layouts/default.njk
+++ b/_includes/layouts/default.njk
@@ -8,8 +8,21 @@
   {% endblock %}
   
   <body class="layout-{{ layout | slug }} page-{{ page.fileSlug }}">
-    
-    {% block header %}
+
+    {# 
+    DEV Note:
+    This adds an overlay while site is under construction.
+    Comment the next line out to remove it.
+    #}
+    {% include "_includes/modules/under-contruction-overlay.njk" %}
+
+
+    {# 
+    DEV Note:
+    Uncomment the rest of these block below to enable original site after
+    commenting out the overlay include above
+    #}
+    {# {% block header %}
       {% include "_includes/base/header.njk" %}
     {% endblock %}
     
@@ -25,7 +38,7 @@
     
     {% block footer_scripts %}
       {% include "_includes/base/footer-scripts.njk" %}
-    {% endblock %}
+    {% endblock %} #}
     
   </body>
 </html>

--- a/_includes/modules/under-contruction-overlay.njk
+++ b/_includes/modules/under-contruction-overlay.njk
@@ -1,0 +1,6 @@
+<div class="fixed top-0 left-0 right-0 bottom-0 w-full h-screen z-50 overflow-hidden bg-gray-900 opacity-95 flex flex-col items-center justify-center">
+    <div class="text-white text-center">
+        <h2 class="text-5xl py-5 font-bold">Coming soon</h2>
+        <p class="text-2xl">Our updated website is coming soon.</p>
+    </div>
+</div>

--- a/index.njk
+++ b/index.njk
@@ -34,7 +34,7 @@ footers:
 ---
 
 {% block content %}
-  
+
   {% include "_includes/modules/home-hero.njk" %}
   
   <div class="container w-11/12 md:w-9/12 mx-auto pt-24 pb-6">


### PR DESCRIPTION
This change give the full site a "coming soon" overlay.

To undo this: just reverse the changes made in `_includes/layouts/default.njk` applied by this PR.